### PR TITLE
i2c component cannot be used from C

### DIFF
--- a/module_i2c/src/i2c.h
+++ b/module_i2c/src/i2c.h
@@ -22,16 +22,17 @@
 #define I2C_MASTER_TX
 #endif
 
-
+#ifndef I2C_MAX_DATA
+#define I2C_MAX_DATA 100
+#endif
 
 struct r_i2c {
 	port scl;
 	port sda;
 };
 
-
 struct i2c_data_info {
-	unsigned int data[100];
+	unsigned int data[I2C_MAX_DATA];
 	unsigned int data_len;
 	unsigned int master_num;
 	unsigned int clock_mul;


### PR DESCRIPTION
Because the header uses XC references.

Admittedly because you need structures of ports you need some XC somewhere to call it but making the interface available should make it more flexible.
