### PR TITLE
reg_read and reg_write now use nbytes params to allow multiple byte register access

### DIFF
--- a/module_i2c_single_port/src/i2c-sp.xc
+++ b/module_i2c_single_port/src/i2c-sp.xc
@@ -108,10 +108,11 @@ int i2c_master_rx(int device, unsigned char data[], int nbytes, port i2c) {
          }
       }
       data[j] = rdData;
-      if(j!=nbytes-1)
+      if(j != nbytes - 1) {
          (void) highPulseDrive(i2c, 0);
-      else
+      } else {
          (void) highPulseSample(i2c, temp);
+      }
    }
    stopBit(i2c);
    return 1;
@@ -141,7 +142,7 @@ int i2c_master_write_reg(int device, int addr, unsigned char s_data[], int nbyte
    {
         data = s_data[i];
         ack |= tx8(i2c, data);
-    }
+   }
    stopBit(i2c);
    return ack == 0;
 }


### PR DESCRIPTION
reg_read and reg_write now use nbytes params to allow multiple byte register access
